### PR TITLE
Issue 162

### DIFF
--- a/src/pages/request-history.page.js
+++ b/src/pages/request-history.page.js
@@ -433,10 +433,13 @@ module.exports = {
         }
     },
 
-    async isDataDisplayed(range, col, check) {
+    async isDataDisplayed(range, col, check, isFailIfNoData) {
         try {
             const noData = await this.isDataReturned()
             if (noData) {
+                if (isFailIfNoData) {
+                    assert.fail(noData)
+                }
                 I.say(noData)
             } else {
                 I.say("Data is available")
@@ -451,8 +454,8 @@ module.exports = {
         await this.isDataDisplayed(range, col, I.checkIfReturnedFilesInDateRange);
     },
 
-    async checkRows(val, col) {
-        await this.isDataDisplayed(val, col, I.checkRowsValue);
+    async checkRows(val, col, isFailIfNoData) {
+        await this.isDataDisplayed(val, col, I.checkRowsValue, isFailIfNoData);
     },
 
     /*
@@ -558,11 +561,11 @@ module.exports = {
         I.seeInField(row, res[1]);
     },
 
-    async checkFileTypeValues(filteredFile) {
-        await this.checkRows(filteredFile, 3)
+    async checkFileTypeValues(filteredFile, isFailIfNoData) {
+        await this.checkRows(filteredFile, 3, isFailIfNoData)
     },
-    async checkFileOutcomeValues(filteredFile) {
-        await this.checkRows(filteredFile, 4);
+    async checkFileOutcomeValues(filteredFile, isFailIfNoData) {
+        await this.checkRows(filteredFile, 4, isFailIfNoData);
     },
 
     applyMultipleFilters(riskFilter, typeFilter) {

--- a/src/utils/steps_file.js
+++ b/src/utils/steps_file.js
@@ -143,12 +143,20 @@ module.exports = function() {
   sendFileICAP: function (fileName, icapDir, testsDir, inputDir, outputDir) {
     const inputPath = `${process.cwd()}/${inputDir}`
     const outputPath = `${process.cwd()}/${outputDir}`
+    const logsName = 'dockerLogs.log'
     // use NodeJS child process to run a bash command in sync way
-    require('child_process').execSync(`cd ${icapDir} && docker run -v ${inputPath}:/opt -v ${outputPath}:/home glasswallsolutions/c-icap-client:manual-v1 -s 'gw_rebuild' -i icap-client-main.uksouth.cloudapp.azure.com -f '/opt/${fileName}' -o /home/${fileName} -v && cd ${testsDir}`, function(err) {
-        if (err) {
-            console.log('err ' + err);
-        }
-      });
+    // create a file for logs
+    require('child_process').execSync(`cd ${icapDir} && rm -f {logsName} && touch -a ${logsName} && cd ${testsDir}`)
+    // run icap client in docker
+    require('child_process').execSync(`cd ${icapDir} && docker run --name=qa-icap-client --rm -v ${inputPath}:/opt -v ${outputPath}:/home glasswallsolutions/c-icap-client:manual-v1 -s 'gw_rebuild' -i icap-client-main.uksouth.cloudapp.azure.com -f '/opt/${fileName}' -o /home/${fileName} -v &> ${logsName} && cd ${testsDir}`)
+    // read logs from file
+    let output = fs.readFileSync(`${icapDir}/${logsName}`);
+    // get file id from logs
+    let fileId = output
+        .toString()
+        .split('X-Adaptation-File-Id: ')[1]
+        .split("\n")[0];
+    return fileId;
   },
   });
 }


### PR DESCRIPTION
content-management-policy-application-to-files.steps.js was updated
Added possibility to get the file id from the ICAP client response, the test fails when no results are displayed in Request history, files content compression was improved, but we have some issues with files with macros (.docm + macros)
